### PR TITLE
ジャンル一覧ページ作成

### DIFF
--- a/app/controllers/admins/items_controller.rb
+++ b/app/controllers/admins/items_controller.rb
@@ -12,7 +12,18 @@ class Admins::ItemsController < ApplicationController
 
   def index
     @genres = Genre.all
+    @items = Item.all
   end
+
+  def show
+    @item = Item.find(params[:id])
+    @genre = Genre.find(params[:id])
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
 
   private
       def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,11 +3,14 @@ class ItemsController < ApplicationController
   def index
   	@items = Item.all
   	@genres = Genre.all
-  	#binding.pry
-  	#@genre = Genre.find(1)
-  	@genre = Genre.find(2)
 
-  	#@genre = Genre.find(params[:id])
+    #条件分岐が必要
+    if params[:genre_id]
+    #if params[:id]
+    	@genre = Genre.find(params[:genre_id])
+      #@genre = Genre.find(params[:id])
+      @items = @genre.items
+    end
   end
 
   def show

--- a/app/views/admins/items/_form.html.erb
+++ b/app/views/admins/items/_form.html.erb
@@ -1,13 +1,8 @@
-<!--パーシャル使用したい-->
-<h1>商品追加</h1>
-
-<%#= render 'admins/items/form', item: @item %>
-
   <div class="row">
     <div class="col-md-6 col-md-offset-3">
-      <%= form_with(model: @item, url:'/admins/items') do |f| %>
+      <%= form_with(model: item, url:'/admins/items') do |f| %>
         <%#= render 'shared/error_messages' %>
-        <%= f.attachment_field :image %><!--画像を表示させる必要がある-->
+        <%= f.attachment_field :image %><!--エラー箇所-->
 
         <%= f.label :商品名 %>
         <%= f.text_field :name, class: 'form-control' %>

--- a/app/views/admins/items/index.html.erb
+++ b/app/views/admins/items/index.html.erb
@@ -1,2 +1,33 @@
-<h1>Admins::Items#index</h1>
-<p>Find me in app/views/admins/items/index.html.erb</p>
+<div class="row">
+  <div class="col-xs-8  col-xs-offset-2">
+
+  	<h1>商品一覧</h1>
+
+	<table class="table table-hover table-inverse">
+	  <thead>
+	  	<tr>
+	  		<th>商品ID</th>
+	  		<th>商品名</th>
+	  		<th>税抜価格</th>
+	  		<th>ジャンル</th>
+	  		<th>ステータス</th>
+	  	</tr>
+	  </thead>
+
+	  <tbody>
+	  	<% @items.each do |item| %>
+	  	  <tr>
+	  		<td><%= item.id %></td>
+	  		<td><%= item.name %></td>
+	  		<td><%= item.price %></td>
+	  		<td><%= item.genre.name %></td>
+	  		<td><%= item.is_soldout %></td><!--ステータスの表示-->
+	  	  </tr>
+	  	<% end %>
+
+	  </tbody>
+
+
+	</table>
+  </div>
+</div>

--- a/app/views/admins/items/show.html.erb
+++ b/app/views/admins/items/show.html.erb
@@ -1,2 +1,26 @@
-<h1>Admins::Items#show</h1>
-<p>Find me in app/views/admins/items/show.html.erb</p>
+<div class="row">
+	<div class="col-xs-4">
+
+		<div class=""><!--画像サイズについて確認-->
+
+		    <%= attachment_image_tag(@item, :image, :fill, 50, 50, fallback: 'no_image.jpg', size: '300x200') %>
+		</div>
+	</div>
+</div>
+
+
+	<div class="col-xs-8"><!--縦並べにしたい-->
+		商品名<%= @item.name %>
+
+		商品説明<%= @item.introduction %>
+
+		ジャンル<%= @genre.name %>
+
+		税込価格(税抜価格)<%= @item.price %> ()円
+
+		販売ステータス<%= @item.is_soldout %>
+
+
+	</div>
+
+

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -13,9 +13,9 @@
 			  <tbody>
 			  		<% @genres.each do |genre| %>
 			  		<tr>
-			  		  <td>
-			  			<!--遷移先を考える-->
-				  		<%= link_to genre.name, items_path %>
+			  		  <td><!--コントローラとビューはセットで考える.下の行の書き方でもok-->
+				  		<%= link_to genre.name, items_path(genre_id: genre.id) %>
+				  		<%#= link_to genre.name, items_path(id: genre.id) %>
 				  	  </td>
 			  		<% end %>
 			  		</tr>
@@ -28,16 +28,19 @@
 
 	<div class="col-xs-8">
 		<!-- ジャンルidに紐づく商品を表示する-->
-		<h2>商品一覧<span>（全◯○件）</span></h2>
+		<% if params[:genre_id] %>
+			<h2>ジャンル一覧<span>（全<%= @items.count %>件）</span></h2>
+		<% else %>
+			<h2>商品一覧<span>（全<%= @items.count %>件）</span></h2>
+		<% end %>
 
-<!-- 		<  % @genre.items.each do |item| %>
-			  < %= link_to item_path(item) do %>
-			    < %= attachment_image_tag(item, :image, :fill, 60, 60, fallback: 'no_image.jpg', size: '65x65') %>
-			  < % end %>
-			  < %= item.name %>
-			  < %= item.price %>
-		  < % end %>
- -->
+			<% @items.each do |item| %>
+				  <%= link_to item_path(item) do %>
+				    <%= attachment_image_tag(item, :image, :fill, 60, 60, fallback: 'no_image.jpg', size: '65x65') %>
+				  <% end %>
+				  <%= item.name %>
+				  <%= item.price %>
+			  <% end %>
 
 	</div>
 


### PR DESCRIPTION
##実装の概要
ジャンル一覧ページを作成しました。
商品一覧のサイドバーにある、ジャンル名をクリックすると、そのジャンルidに紐づく、ジャンル一覧が表示されるようになります。

＃保留してること
レイアウトに関しては、調整が必要です。
