### PR TITLE
注文入力ページ機能追加

### DIFF
--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -1,3 +1,4 @@
 // Place all the styles related to the Orders controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -10,7 +10,7 @@ class OrdersController < ApplicationController
 
   def create
     @order = Order.new(order_params)
-    @order_end_user_id = current_end_user.id
+    @order.end_user_id = current_end_user.id
     if @order.save
       redirect_to orders_finish_path
     else
@@ -28,16 +28,7 @@ class OrdersController < ApplicationController
       @order = Order.find(params[:order_id])
       @order_items = @order.order_items
    end
-    # @order_item = OrderItem
 
-
-    #     #条件分岐が必要
-    # if params[:genre_id]
-    # #if params[:id]
-    #   @genre = Genre.find(params[:genre_id])#ここのコードの意味
-    #   #@genre = Genre.find(params[:id])
-    #   @items = @genre.items
-    # end
   end
 
   def finish

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,15 @@
 class Order < ApplicationRecord
+	belongs_to :user #追記
 	has_many :order_items
+
 	enum order_status:{ waiting: 0, confirmation: 1, progress: 2, preparing: 3, shipped: 4 }
+
+	enum payment_method: {
+		credit_card: 0,
+		bank_transfer: 1
+
+	}
+
 end
 
 

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -11,7 +11,7 @@
     	</tr>
     </thead>
     <tbody>
-    	<!--each文で回して、データ取ってくる、関連付け必要-->
+
     	<% @orders.each do |order| %>
     	<tr>
     		<td><%= order.created_at %></td>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,72 +1,84 @@
 <div class="row">
-  <div class="col-md-6 col-md-offset-1">
-
+  <div class="col-xs-6 col-xs-offset-1">
 	<h3>注文情報入力</h3>
-
-	<%= form_with(model: @order, url: orders_path) do |f| %>
-	<%#= render 'shared/error_messages' %>
-		<table class="order-new table">
-			<tr>
-			  <th>支払方法</th>
-		    </tr>
-		      <td><%= f.radio_button :payment_method, :"0" %>
-				    <%= f.label :payment_method, "クレジットカード", {value: :"0", style: "display: inline-block;"} %><br />
-
-			  	<%= f.radio_button :payment_method, :"1" %>
-				<%= f.label :payment_method, "銀行振込", {value: :"1", style: "display: inline-block;"} %>
-			  </td>
-			</tr>
-
-	  	    <tr>
-	  	      <th>お届け先</th>
-	  	    </tr>
-	  	    <tr>
-	  	      <td><!--ラジオボタンの書き方-->
-	  	      	<%= f.radio_button :address, :"current_end_user.address" %>
-	  	      	<%= f.label 'ご自身の住所' %>
-	  	      	<%= current_end_user.address %>
-
-	  	      </td>
-	  	    </tr>
-	  	    <tr>
-	  	      <td><!--ラジオボタンの書き方-->
-	  	      	<%= f.radio_button :address, :"登録先住所から選択" %>
-				<%= f.label '登録済住所から選択' %>
-
-	  	      </td>
-	  	    </tr>
-	  	    <tr><!--ラジオボタンの書き方-->
-		      <th><%= f.radio_button :address, :"" %>  新しいお届け先</th>
-		    </tr>
-		    <tr>
-		      <td>
-				<%= f.label '郵便番号(ハイフンなし)' %>
-				<%= f.text_field :postal_code %>
-      		  </td>
-      		</tr>
-
-      		<tr>
-			  <td><!--位置の調整がうまくいかない-->
-				<%= f.label '住所' %>
-				<%= f.text_field :address %>
-			  </td>
-			</tr>
-			<tr>
-				<td><!--位置の調整がうまくいかない-->
-				  <%= f.label '宛名' %>
-				  <%= f.text_field :name %>
-				</td>
-			</tr>
-		</table>
-	  <% end %>
-	</div>
+  </div>
 </div>
-
 
 <div class="row">
-	<div class="col-md-6 col-md-offset-1">
-		<div class="actions">
-			<%= link_to '確認画面へ進む', orders_detail_path, class: 'btn btn-default btn-primary' %>
+
+  <div class="form-horizontal">
+    <%= form_with(model: @order, url: orders_detail_path, local:true) do |f| %>
+
+	  <%#= render 'shared/error_messages' %>
+	  <div class="form-group">
+	  	<div class="col-xs-6 col-xs-offset-2">
+	  	  <label class="control-label">支払い方法</label>
+	    </div>
+	  </div>
+
+	  <div class="form-group">
+	    <div class="col-xs-6 col-xs-offset-2">
+		    <%= f.radio_button :payment_method, :credit_card %>クレジットカード
+			<%#= f.label :payment_method, "クレジットカード", {value: :"0", style: "display: inline-block;"} %><br />
 		</div>
-	</div>
+	  </div>
+	  <div class="form-group">
+	  	<div class="col-xs-6 col-xs-offset-2">
+		  	<%= f.radio_button :payment_method, :bank_transfer %>銀行振込
+
+			<%#= f.label :payment_method, "銀行振込", {value: 1, style: "display: inline-block;"} %>
+		</div>
+	  </div>
+
+	  <!--以降、お届け先入力欄-->
+	  <div class="form-group">
+	  	<div class="col-xs-6 col-xs-offset-2">
+	  	  <label class="control-label">お届け先</label>
+	  	</div>
+	  </div><!--プロパティ名と値をセットで指定する必要がある--><!--valueも書いたけど、なくてもいけるみたいでよくわからない-->
+	  <div class="form-group">
+	    <div class="col-xs-6 col-xs-offset-2">
+	    	<%= f.radio_button :address, 1 %>
+	    	<!--住所の表示をさせること-->
+	    	<%= f.label :address, 'ご自身の住所', style:'display: inline-block;' %>
+	    </div>
+	  </div>
+	  <!--登録先住所-->
+	  <div class="form-group">
+	  	<div class="col-xs-6 col-xs-offset-2">
+	    	<%= f.radio_button :address, 2 %>
+	    	<%= f.label :address, '登録先住所から選択',style:'display: inline-block;' %>
+	  	</div>
+	  </div>
+	  <!--新しい住所-->
+	  <div class="form-group">
+	  	<div class="col-xs-6 col-xs-offset-2">
+
+	  		<!--ラジオボタンの書き方-->
+	  		<%= f.radio_button :address, 3 %>
+	  		<%= f.label :address, '新しいお届け先', value: 3, style: 'display: inline-block;' %><br />
+
+	  		<%= f.label '郵便番号(ハイフンなし)' %>
+	  		<%= f.text_field :postal_code %><br />
+
+	  		<%= f.label '住所' %>
+	  		<%= f.text_field :address %><br />
+
+	  		<%= f.label '宛名' %>
+	  		<%= f.text_field :name %>
+		</div>
+	  </div>
+
+	  <div class="form-group">
+	  	<div class="col-xs-6 col-xs-offset-2">
+	  	  <div class="actions">
+	  		  <%= f.submit '確認画面へ進む', class: 'btn btn-default btn-primary' %>
+	  	  </div>
+	  	</div>
+	  </div>
+
+	  <% end %>
+  </div>
 </div>
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   resources :cart_items, only: [:create, :index, :update, :destroy]
   delete '/cart_items_delete' => 'cart_items#empty', as: 'cart_items_delete'
 
-  get '/orders/detail' => 'orders#detail', as: 'orders_detail'
+  post '/orders/detail' => 'orders#detail', as: 'orders_detail'
   get '/orders/finish' => 'orders#finish'
   resources :orders, only: [:index, :new, :create, :show]
 


### PR DESCRIPTION
##実装概要
-注文ページviewの「確認画面へ進む」ボタンを押すと、detail-viewページに遷移します。
-注文情報はform_withでデータを送るようにしています。

##変更点
ルーティング設計書では、orderコントローラのdetailアクションは、HTTPメソッドがGETということでしたが、
form_withでコードを記述するようにしたため、POSTに変更しました。
