### PR TITLE
注文情報入力機能の修正

### DIFF
--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -1,5 +1,5 @@
 class Admins::OrdersController < ApplicationController
-  
+
   before_action :authenticate_admin!
 
   def index

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -4,4 +4,10 @@ class Delivery < ApplicationRecord
 	#配送先の登録
 	validates :name, presence:true
 	validates :address, presence:true
+
+
+	#複数カラムの結合　登録先住所+(名前)
+	def view_address_and_name
+	   self.address + '(' + self.name + ')'
+	end
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,5 +1,9 @@
 class Genre < ApplicationRecord
 	has_many :items
-	validates :name,  presence: true, length: { maximum: 20 }
+	validates :name, presence: true,
+					 uniqueness: true,
+					 length: { maximum: 20 }
+
 	validates :is_invalid, inclusion: { in: [true, false] }
 end
+

--- a/app/views/orders/detail.html.erb
+++ b/app/views/orders/detail.html.erb
@@ -64,9 +64,10 @@
 	    <tr>
 			<th>お届け先</th>
 			<td><!--ラジオボタンの番号によって表示を変える-->
-				<%= @order.postal_code %>
-				<%= @order.address %>
-				<%= @order.name %>
+				<%# if @order[:radio_button] != "2" %>
+					〒<%= @order.postal_code %>
+					<%= @order.address %>
+					<%= @order.name %>
 			</td>
 	    </tr>
 
@@ -76,8 +77,9 @@
 	<!--注文情報確定ボタン-->
 	<div class="row">
 		<%= form_with(model: @order,url: orders_path,local:true) do |f| %>
-			<!--購入者名 追加-->
+			<!--お届け先氏名 -->
 			<%= f.hidden_field :name, :value => @order.name %>
+
 			<!--支払い方法-->
 			<%= f.hidden_field :payment_method, :value => @order.payment_method %>
 			<!--お届け先-->

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -49,8 +49,9 @@
 	  		<!--住所データはDeliveryモデルから取ってこれる-->
 	    	<%= radio_button_tag :radio_button, 2 %>
 	    	<%= f.label :address, '登録先住所から選択',style:'display: inline-block;' %><br />
-	    	<!--セレクトボタン--><!--:idから:nameに変更 0610-->
-	    	<%= f.collection_select :delivery_id, current_end_user.deliveries, :name, :address, :include_blank => true %>
+	    	<!--セレクトボタン-->
+	    	<!--deliveryモデルに定義-->
+	    	<%= f.collection_select :delivery_id, current_end_user.deliveries, :id, :view_address_and_name, :include_blank => true %>
 	  	</div>
 	  </div>
 	  <!--新しい住所-->


### PR DESCRIPTION
#実装概要
-ラジオボタン２番の住所で、注文情報入力画面に進むと、エラー発生していたので、修正しました
-配送先の選択時に、住所と名前カラムを連結させて表示できるようにしました

