### PR TITLE
配送先情報機能修正

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -51,7 +51,8 @@ class OrdersController < ApplicationController
       @order.name = current_end_user.last_name
       #@order.first_name = current_end_user.first_name
     elsif params[:radio_button] == "2"
-      if params[:delivery_id]
+      if params[:order][:delivery_id]
+
         @delivery = Delivery.find(params[:order][:delivery_id]) #記述
         @order.postal_code = @delivery.postal_code
         @order.address = @delivery.address
@@ -60,7 +61,7 @@ class OrdersController < ApplicationController
         redirect_to new_order_path, danger: 'お届け先情報を選択してください'
       end
     else
-      if params[:address]
+      if params[:order][:address].present? && params[:order][:postal_code].present? && params[:order][:name].present?
         @order.postal_code = params[:order][:postal_code]
         @order.address = params[:order][:name]
         @order.name = params[:order][:address]

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -51,7 +51,7 @@
 	    	<%= radio_button_tag :radio_button, 2 %>
 	    	<%= f.label :address, '登録先住所から選択',style:'display: inline-block;' %><br />
 	    	<!--セレクトボタン-->
-	    	<!--deliveryモデルに定義-->
+	    	<!--deliveryモデルに定義されている情報を取ってくる-->
 	    	<%= f.collection_select :delivery_id, current_end_user.deliveries, :id, :view_address_and_name,:include_blank => true %>
 	  	</div>
 	  </div>


### PR DESCRIPTION
＃実装概要
-配送先情報の入力機能を修正しました。
-配送先情報に不備がある場合、注文画面へ進めないようにしました
-配送先の選択(ラジオボタン２、３番）の機能を修正しました
